### PR TITLE
--exclusive fix for the while loop

### DIFF
--- a/while.sh
+++ b/while.sh
@@ -5,7 +5,7 @@
 
 while read a b c
 do
-    srun -n 1 ./code.sh $a $b $c > $a-$b-$c.out &
+    srun -n 1 --output=$a-$b-$c.out --exclusive ./code.sh $a $b $c &
 done < parameters.dat
 
 wait


### PR DESCRIPTION
There must have been a change in the way srun runs in parallel, the `--exclusive` flag seems to be required now.
I also used the "cleaner" `--output=<outputfile>` option.